### PR TITLE
Minor Evo 2 update

### DIFF
--- a/data/mods/gen9evolutionproject/pokedex.ts
+++ b/data/mods/gen9evolutionproject/pokedex.ts
@@ -1269,15 +1269,17 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 		baseStats: {hp: 103, atk: 79, def: 53, spa: 89, spd: 67, spe: 134},
 		abilities: {0: "Adaptability", H: "Normalize", S: "Beast Boost"},
 		movepoolAdditions: [
+			"reflecttype", "terrainpulse",
 			"blizzard", "chargebeam", "discharge", "expandingforce", "futuresight", "gigaimpact", "haze", "hyperbeam", "icebeam", "icywind", "magiccoat",
-			"naturepower", "psychic", "psyshock", "reflect", "reflecttype", "risingvoltage", "scald", "shockwave", "signalbeam", "skillswap", "snarl", "solarbeam",
-			"suckerpunch", "surf", "terrainpulse", "thunder", "thunderbolt", "thunderwave", "trick", "voltswitch", "waterpulse", "wonderroom", "zapcannon",
+			"naturepower", "psychic", "psyshock", "reflect", "risingvoltage", "scald", "shockwave", "signalbeam", "skillswap", "snarl", "solarbeam",
+			"suckerpunch", "surf", "thunder", "thunderbolt", "thunderwave", "trick", "voltswitch", "waterpulse", "wonderroom", "zapcannon",
 		],
 
 		prevo: "Eevee",
 		evoType: "levelExtra",
 		evoCondition: "in Ultra Space",
 		creator: "inkbug",
+		description: `<i>(Aleon's moves are handpicked from the other evolutions of Eevee, except Reflect Type and Terrain Pulse.)</i>`,
 	},
 
 	qwilfish: {
@@ -1659,15 +1661,15 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 	tapukiki: {
 		name: "Tapu Kiki",
 		copyData: "Tapu Koko",
-		copyMoves: "Cosmog", // sloppy shortcuts yay
 
 		types: ["Fairy"],
 		baseStats: {hp: 70, atk: 75, def: 95, spa: 75, spd: 95, spe: 115},
 		abilities: {0: "Power Surge", H: "Friend Guard"},
-		movepoolAdditions: ["dragoncheer", "dragonhammer", "allyswitch", "aromatherapy", "bulkup", "calmmind", "confide", "dazzlinggleam", "defog", "drainingkiss", "echoedvoice", "endure", "facade", "falseswipe", "fling", "focusblast", "frustration", "grassknot", "gravity", "guardswap", "hiddenpower", "icywind", "irondefense", "knockoff", "lightscreen", "magiccoat", "magicroom", "meanlook", "moonblast", "naturepower", "nature'smadness", "playrough", "powerswap", "protect", "psychup", "raindance", "reflect", "rest", "return", "roar", "rototiller", "round", "safeguard", "shadowball", "sleeptalk", "smartstrike", "snore", "storedpower", "substitute", "sunnyday", "swagger", "taunt", "telekinesis", "thief", "thunderwave", "torment", "toxic", "trick", "voltswitch", "withdraw", "wonderroom", "workup"],
-		movepoolDeletions: ["teleport", "splash"],
+		movepoolAdditions: ["dragoncheer", "dragonhammer", "allyswitch", "aromatherapy", "bulkup", "drainingkiss", "fling", "focusblast", "gravity", "guardswap", "icywind", "knockoff", "magiccoat", "magicroom", "moonblast", "playrough", "rototiller", "shadowball", "smartstrike", "sunnyday", "trick", "wonderroom"],
+		movepoolDeletions: ["acrobatics", "aerialace", "agility", "assurance", "bravebird", "charge", "discharge", "doubleteam", "eerieimpulse", "electricterrain", "electroball", "electroweb", "fairywind", "fly", "gigaimpact", "hyperbeam", "hypervoice", "ironhead", "mirrormove", "quickattack", "roost", "screech", "shockwave", "skyattack", "skydrop", "spark", "steelwing", "swift", "thunder", "thunderbolt", "thunderpunch", "thundershock", "uturn", "wildcharge"],
 
 		creator: "quagsi",
+		description: `<i>(Tapu Kiki's moves are handpicked from the combination of Tapu Koko, Tapu Lele, Tapu Bulu and Tapu Fini, except Dragon Cheer and Dragon Hammer, which represent Exeggutor Island.)</i>`,
 	},
 
 	thievul: {
@@ -1927,6 +1929,7 @@ export const Pokedex: {[speciesid: string]: ModdedSpeciesData} = {
 
 		evos: ["Zacian", "Zamazenta"],
 		creator: "Gravity Monkey",
+		description: `<i>(Zavender learns only the moves that both Zacian and Zamazenta can learn.)</i>`,
 	},
 	zacian: {
 		inherit: true,

--- a/data/mods/gen9evolutionproject/rulesets.ts
+++ b/data/mods/gen9evolutionproject/rulesets.ts
@@ -33,12 +33,35 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 				let extraLineBreak = false;
 				let hideBox = `raw|<div class="infobox" open><details class ="details"><summary>Fakemon on ${side.name}'s team</summary>`;
 				for (const pokemon of side.pokemon) {
-					// add one more line between each Fakemon
-					if (extraLineBreak) hideBox += `<br>`;
-					else extraLineBreak = true;
-					
 					let species = this.dex.species.get(pokemon.species.name);
-					if (species.copyData) { // all modded things in Evo have this
+					
+					// add one more line between each Fakemon
+					if (species && (species.copyData || (species.evos && species.evos.length))) {
+						if (extraLineBreak) hideBox += `<br>`;
+						else extraLineBreak = true;
+					}
+
+					// report Eviolite compatibility even for canon Pokémon
+					if (species && !species.copyData && (species.evos && species.evos.length)) {
+						showFakemon = true;
+						hideBox += `<br><div class="hint">${species.name} <strong>can use Eviolite</strong> because it evolves into`;
+						let order = 0;
+						for (const evoname of species.evos) {
+							order++;
+							if (order < species.evos.length) {
+								hideBox += ` ${evoname}`;
+								if (order + 1 < species.evos.length) hideBox += `,`;
+							}
+							else {
+								if (species.evos.length !== 1) hideBox += ` and`;
+								hideBox += ` ${evoname}`;
+							}
+						}
+						hideBox += `!</div><br>`;
+					}
+
+					// otherwise, Fakemon
+					if (species && species.copyData) { // all modded things in Evo have this
 						showFakemon = true;
 						let abilities = species.abilities[0];
 						if (species.abilities[1]) abilities += ` / ${species.abilities[1]}`;
@@ -54,6 +77,23 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 						// creator
 						if (species.creator) {
 							customGuide += `<div class="hint"><br>${species.name} was created by ${species.creator}!</div>`;
+						}
+
+						if (species.evos && species.evos.length) {
+							customGuide += `<br><div class="hint">It <strong>can use Eviolite</strong> because it evolves into`;
+							let order = 0;
+							for (const evoname of species.evos) {
+								order++;
+								if (order < species.evos.length) {
+									customGuide += ` ${evoname}`;
+									if (order + 1 < species.evos.length) customGuide += `,`;
+								}
+								else {
+									if (species.evos.length !== 1) customGuide += ` and`;
+									customGuide += ` ${evoname}`;
+								}
+							}
+							customGuide += `!</div>`;
 						}
 						
 						// movepool changes
@@ -170,7 +210,7 @@ export const Rulesets: {[k: string]: ModdedFormatData} = {
 						}
 
 						// other info
-						if (species.description) customGuide += `<br><div class="hint"><br>${species.description}</div>`;
+						if (species.description) customGuide += `<br><div class="hint">${species.description}</div>`;
 						
 						customGuide += `<br></details></div>`;
 						hideBox += customGuide;

--- a/data/mods/gen9evolutionproject/scripts.ts
+++ b/data/mods/gen9evolutionproject/scripts.ts
@@ -14,15 +14,20 @@ export const Scripts: {[k: string]: ModdedBattleScriptsData} = {
 	init() {
 		let customList = [];
 		let dexNo = -1;
+		const notm = ['terablast', 'hiddenpower']; // certain moves don't count TMs
+		const gen9only = [
+			'plankteenie', 'mareaniedrifter', 'toxapexglacial', 'nemesyst', 'numeldormant', 'dormedary', 'dormaderupt',
+			'uraxys', 'cytoxys', 'adexys', 'guaxys', 'riboxysu', 'riboxysc', 'riboxysa', 'riboxysg',
+		]; // certain Fakemon are based on Gen IX movepools specifically
+		
 		for (const id in this.dataCache.Pokedex) {
-			const notm = ['terablast', 'hiddenpower']; // certain moves don't count TMs
-			const gen9only = [
-				'plankteenie', 'mareaniedrifter', 'toxapexglacial', 'nemesyst', 'numeldormant', 'dormedary', 'dormaderupt',
-				'uraxys', 'cytoxys', 'adexys', 'guaxys', 'riboxysu', 'riboxysc', 'riboxysa', 'riboxysg',
-			]; // certain Fakemon are based on Gen IX movepools specifically
+			if (
+				!(this.dataCache.Pokedex[id] && this.dataCache.Pokedex[id].copyData) &&
+				!(this.modData('FormatsData', id) && this.modData('FormatsData', id).tier && ['Evo!', '(Prevo)'].includes(this.modData('FormatsData', id).tier))
+			) continue; // skip canon Pokémon that aren't in the dex - but allow Fakemon for both
 
-			// movepool corrections
 			if (this.dataCache.Learnsets[id]) {
+				// movepool corrections
 				for (const moveid of notm) {
 					if (this.dataCache.Learnsets[id].learnset && this.dataCache.Learnsets[id].learnset[moveid]) {
 						// check if it learns the move naturally
@@ -35,47 +40,48 @@ export const Scripts: {[k: string]: ModdedBattleScriptsData} = {
 
 			// Fakemon creation
 			const newMon = this.dataCache.Pokedex[id];
-			if (!newMon || !newMon.copyData) continue; // weeding out Pokémon that aren't new
-			const copyData = this.dataCache.Pokedex[this.toID(newMon.copyData)];
-
-			if (!newMon.types && copyData.types) newMon.types = copyData.types;
-			if (!newMon.baseStats && copyData.baseStats) newMon.baseStats = copyData.baseStats;
-			if (!newMon.abilities && copyData.abilities) newMon.abilities = copyData.abilities;
-			// if (!newMon.num && copyData.num) newMon.num = copyData.num * -1; // inverting the original's dex number
-			if (!newMon.genderRatio && copyData.genderRatio) newMon.genderRatio = copyData.genderRatio;
-			if (!newMon.heightm && copyData.heightm) newMon.heightm = copyData.heightm;
-			if (!newMon.weightkg && copyData.weightkg) newMon.weightkg = copyData.weightkg;
-			if (!newMon.color && copyData.color) newMon.color = copyData.color;
-			if (!newMon.eggGroups && copyData.eggGroups) newMon.eggGroups = copyData.eggGroups;
-			
-			// actually, handling dex numbers that way creates issues with species clause! let's fix that:
-			if (newMon.baseSpecies) {
-				newMon.num = this.dataCache.Pokedex[this.toID(newMon.baseSpecies)].num;
-			} else {
-				newMon.num = dexNo;
-				dexNo--;
-			}
-
-			if (!newMon.evos) customList.push(id); // only fully-evolved Pokémon of the Day!
-
-			let copyMoves = newMon.copyData;
-			if (newMon.copyMoves) copyMoves = newMon.copyMoves;
-			if (copyMoves) {
-				if (!this.dataCache.Learnsets[id]) this.dataCache.Learnsets[id] = {learnset: {}}; // create a blank learnset entry so we don't need a learnsets file
-				const learnset = this.dataCache.Learnsets[this.toID(copyMoves)].learnset;
-				for (const moveid in learnset) {
-					this.modData('Learnsets', id).learnset[moveid] = learnset[moveid].filter(
-						(method) => !(method.includes('S') || (notm.includes(moveid) && (method.includes('M') || method.includes('T') || method.includes('V'))) || (gen9only.includes(id) && !(method.startsWith('9'))))
-					);
+			if (newMon && newMon.copyData) { // weeding out Pokémon that aren't new
+				const copyData = this.dataCache.Pokedex[this.toID(newMon.copyData)];
+	
+				if (!newMon.types && copyData.types) newMon.types = copyData.types;
+				if (!newMon.baseStats && copyData.baseStats) newMon.baseStats = copyData.baseStats;
+				if (!newMon.abilities && copyData.abilities) newMon.abilities = copyData.abilities;
+				// if (!newMon.num && copyData.num) newMon.num = copyData.num * -1; // inverting the original's dex number
+				if (!newMon.genderRatio && copyData.genderRatio) newMon.genderRatio = copyData.genderRatio;
+				if (!newMon.heightm && copyData.heightm) newMon.heightm = copyData.heightm;
+				if (!newMon.weightkg && copyData.weightkg) newMon.weightkg = copyData.weightkg;
+				if (!newMon.color && copyData.color) newMon.color = copyData.color;
+				if (!newMon.eggGroups && copyData.eggGroups) newMon.eggGroups = copyData.eggGroups;
+				
+				// actually, handling dex numbers that way creates issues with species clause! let's fix that:
+				if (newMon.baseSpecies) {
+					newMon.num = this.dataCache.Pokedex[this.toID(newMon.baseSpecies)].num;
+				} else {
+					newMon.num = dexNo;
+					dexNo--;
 				}
-				if (newMon.movepoolAdditions) {
-					for (const move of newMon.movepoolAdditions) {
-						this.modData('Learnsets', this.toID(id)).learnset[this.toID(move)] = ["9M"];
+	
+				if (!newMon.evos) customList.push(id); // only fully-evolved Pokémon of the Day!
+	
+				let copyMoves = newMon.copyData;
+				if (newMon.copyMoves) copyMoves = newMon.copyMoves;
+				if (copyMoves) {
+					if (!this.dataCache.Learnsets[id]) this.dataCache.Learnsets[id] = {learnset: {}}; // create a blank learnset entry so we don't need a learnsets file
+					const learnset = this.dataCache.Learnsets[this.toID(copyMoves)].learnset;
+					for (const moveid in learnset) {
+						this.modData('Learnsets', id).learnset[moveid] = learnset[moveid].filter(
+							(method) => !(method.includes('S') || (notm.includes(moveid) && (method.includes('M') || method.includes('T') || method.includes('V'))) || (gen9only.includes(id) && !(method.startsWith('9'))))
+						);
 					}
-				}
-				if (newMon.movepoolDeletions) {
-					for (const move of newMon.movepoolDeletions) {
-						delete this.modData('Learnsets', this.toID(id)).learnset[this.toID(move)];
+					if (newMon.movepoolAdditions) {
+						for (const move of newMon.movepoolAdditions) {
+							this.modData('Learnsets', this.toID(id)).learnset[this.toID(move)] = ["9M"];
+						}
+					}
+					if (newMon.movepoolDeletions) {
+						for (const move of newMon.movepoolDeletions) {
+							delete this.modData('Learnsets', this.toID(id)).learnset[this.toID(move)];
+						}
 					}
 				}
 			}


### PR DESCRIPTION
- Improves the presentation of Data Mod a little - it's now transparent about Eviolite compatibility (since it's the one thing that can change about even vanilla Pokémon) and clearer about where Tapu Kiki, Aleon and Zavender's movepools come from
- The movepool section of scripts.ts now skips over Pokémon that aren't in the mod, which is a small optimization now but will be handy for the next update